### PR TITLE
Instagram.social updated

### DIFF
--- a/data/addons/default/icons.toml
+++ b/data/addons/default/icons.toml
@@ -57,7 +57,7 @@
 [instagram]
 	class = "fa fa-instagram"
 [instagram.social]
-	class = "fa fa-instagram-square"
+	class = "fa fa-instagram"
 
 [linkedin]
 	class = "fa fa-linkedin"


### PR DESCRIPTION
instagram icon doesn't have a square format, updated to normal version.
